### PR TITLE
Allow using existing sasl passwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,34 +9,30 @@ This relay is restricted to only one domain name. so it means that only mail tha
 
 :warning: Take care of the [changelogs](CHANGELOG.md) because some breaking changes may happend between versions.
 
-### Example of usage
+## Example of usage
 
 This relay can take place into a information system if you want to give access to some web or other applications a way to send notification by mail.
 
 The advantage of this configuration is that only the host in theses case are allowed to send emails through this relay :
 
-   * The host IP's address is in the range of RELAY_MYNETWORKS
-   * The host is authenticated with a valid SASL login/password
-
-
+* The host IP's address is in the range of RELAY_MYNETWORKS
+* The host is authenticated with a valid SASL login/password
 
 ## Docker Informations
 
-   * This port is available on this image
+* This port is available on this image
 
 | Port   | Usage                         |
 | ------ | ----------------------------  |
 | 25     | SMTP for incoming relay user  |
 
-   * This volume is bind on this image
+* This volume is bind on this image
 
 | Volume  | Usage                                                   |
 | --------| ------------------------------------------------------- |
 | /data   | Contains the flat database that contains all SASL user  |
 
-
-  * This image takes theses environnements variables as parameters
-
+* This image takes theses environnements variables as parameters
 
 | Environment                  | Type                | Usage                                                                                                                                                          |
 | ---------------------------- | ------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -45,17 +41,17 @@ The advantage of this configuration is that only the host in theses case are all
 | RELAY_MYNETWORKS             | List of strings     | The space separated list of network(s) which are allowed by default to relay emails                                                                            |
 | RELAY_DOMAINS                | List of strings     | The space separated list of external domain names for whose this relay will forward email. Useless if you use a *NODOMAIN relay mode. Default to RELAY_MYDOMAIN|
 | RELAY_HOST       (mandatory) | String              | The remote host to which send the relayed emails (the relayhost)                                                                                               |
-| RELAY_LOGIN                  | String              | The login name to present to the relayhost during authentication (optionnal)                                                                                   |
-| RELAY_PASSWORD               | String              | The password to present to the relayhost during authentication (optionnal)                                                                                     |
+| RELAY_LOGIN                  | String              | The login name to present to the relayhost during authentication (optional)                                                                                   |
+| RELAY_PASSWORD               | String              | The password to present to the relayhost during authentication (optional)                                                                                     |
 | RELAY_USE_TLS                | Boolean(yes/no)     | Specify if you want to require a TLS connection to relayhost                                                                                                   |
 | RELAY_TLS_VERIFY             | Enum                | How to verify the TLS  : (none, may, encrypt, dane, dane-only, fingerprint, verify, secure)                                                                    |
 | RELAY_TLS_CA                 | String path         | The path to the CA file use to check relayhost certificate (path in the container)                                                                             |
 | RELAY_POSTMASTER             | String email address| The email address of the postmaster, in order to send error, and misconfiguration notification                                                                 |
-| RELAY_STRICT_SENDER_MYDOMAIN | Boolean(true/false) | If set to 'true' all sender adresses must belong to the relay domains                                                                                          |
+| RELAY_STRICT_SENDER_MYDOMAIN | Boolean(true/false) | If set to 'true' all sender addresses must belong to the relay domains                                                                                          |
 | RELAY_MODE                   | Enum                | The predefined mode of relay behaviour, theses modes has been designed by me. The availables values for this parameter are described below                     |
-| RELAY_EXTRAS_SETTINGS        | List of string      | Space separated of extras optiosn that will be passed to postconf -e                                                                                           |
+| RELAY_EXTRAS_SETTINGS        | List of string      | Space separated of extras options that will be passed to postconf -e                                                                                           |
 
-#### Relay Mode
+### Relay Mode
 
 Description of parameter
 
@@ -72,20 +68,20 @@ For other examples of values, you can refer to the Dockerfile
 
 * Manual
 
-```
+```bash
 git clone
 docker build -t turgon37/smtp-relay .
 ```
 
 * or Automatic
 
-```
+```bash
 docker pull turgon37/smtp-relay
 ```
 
 ## Usage
 
-```
+```bash
 docker run -p 25:25 -e "RELAY_MYDOMAIN=domain.com" -e "RELAY_HOST=relay:25" docker-smtp-relay
 ```
 
@@ -93,7 +89,7 @@ docker run -p 25:25 -e "RELAY_MYDOMAIN=domain.com" -e "RELAY_HOST=relay:25" dock
 
 * unauthenticated smtp relay filtered by subnet and domain name
 
-```
+```yaml
 services:
   smtp-relay:
     image: turgon37/smtp-relay:latest
@@ -109,7 +105,7 @@ services:
 
 * authenticated smtp proxy
 
-```
+```yaml
 services:
   smtp-relay-auth:
     image: turgon37/smtp-relay:latest
@@ -134,25 +130,25 @@ volumes:
 
 ### Configuration during running
 
-   * List all SASL users :
+* List all SASL users :
 
-```
+```bash
 docker exec smtp-relay /opt/postfix/listpasswd.sh
 ```
 
-   * Add a SASL user :
+* Add a SASL user :
 
 If you have a host which is not in the range of addresses specified in 'mynetworks' of postfix, this host have to be sasl authenticated when it connects to the smtp relay.
 
 To create a generic account for this host you have to run this command into the container
 
-```
+```bash
 docker exec -it smtp-relay /opt/postfix/saslpasswd.sh -u domain.com -c username
 ```
 
 You have to replace domain.com with your relay domain and you will be prompt for password two times. Then you will be prompted for password two times
 
-   * Add multiple SASL users :
+* Add multiple SASL users :
 
 If you want to add multiple sasl users at the same time you can mount (-v) your credentials list to /etc/postfix/client_sasl_passwd
 This list must contains one credential per line and for each line use the syntax  'USERNAME PASSWORD'  (the username and the password are separated with a blank space)

--- a/README.md
+++ b/README.md
@@ -128,6 +128,42 @@ volumes:
   data-smtp-relay-auth:
 ```
 
+### Using external relay credentials
+
+If you want to prevent having your relay credentials in your docker-compose file, you can mount them (instead of setting
+`RELAY_LOGIN`and `RELAY_PASSWORD` variables) into `/etc/postfix/sasl_passwd` 
+
+Taking again our `authenticated smtp proxy` example above, we would now have:
+
+```yaml
+services:
+  smtp-relay-auth:
+    image: turgon37/smtp-relay:latest
+    environment:
+      - RELAY_POSTMASTER=postmaster@example.net
+      - RELAY_MYHOSTNAME=smtp-relay.example.net
+      - RELAY_MYDOMAIN=example.net
+      - RELAY_MYNETWORKS=127.0.0.0/8 10.0.0.0/24
+      - RELAY_HOST=[10.1.0.1]:25
+      - RELAY_MODE=ALLOW_SASLAUTH_NODOMAIN
+      - RELAY_USE_TLS=no
+      - 'RELAY_EXTRAS_SETTINGS=compatibility_level=1'
+    ports:
+      - "10.0.0.1:3000:25"
+    volumes:
+      - data-smtp-relay-auth:/data
+      - "/my/local/path/sasl_passwd:/etc/postfix/sasl_passwd"
+volumes:
+  data-smtp-relay-auth:
+```
+
+And our local `sasl_passwd` file would have as contents:
+
+```bash
+user@host:~$cat /my/local/path/sasl_passwd
+[10.1.0.1]:25 sasl-user-login:xxxxxxxxxxxx  
+```
+
 ### Configuration during running
 
 * List all SASL users :

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,9 +73,9 @@ if expr match $1 '.*supervisord' >/dev/null; then
   if [ -f $aliases ]; then
     newaliases
   fi
-  
+
   # Configure authentification to relay if needed
-  if [ -n "${RELAY_LOGIN}" -a -n "${RELAY_PASSWORD}" ]; then
+  if [ \( -n "${RELAY_LOGIN}" -a -n "${RELAY_PASSWORD}" \) -o \( -f /etc/postfix/sasl_passwd \) ]; then
     postconf -e 'smtp_sasl_auth_enable = yes'
     # use password from hash database
     if [ -f /etc/postfix/sasl_passwd ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,13 +77,13 @@ if expr match $1 '.*supervisord' >/dev/null; then
   # Configure authentification to relay if needed
   if [ \( -n "${RELAY_LOGIN}" -a -n "${RELAY_PASSWORD}" \) -o \( -f /etc/postfix/sasl_passwd \) ]; then
     postconf -e 'smtp_sasl_auth_enable = yes'
-    # use password from hash database
-    if [ -f /etc/postfix/sasl_passwd ]; then
-      postconf -e 'smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd'
-      postmap /etc/postfix/sasl_passwd
-    else
+    # use password from hash database    
+    if [ -n "${RELAY_LOGIN}" -a -n "${RELAY_PASSWORD}" ]; then
      # use static database
       postconf -e "smtp_sasl_password_maps = inline:{${RELAY_HOST}=${RELAY_LOGIN}:${RELAY_PASSWORD}}"
+    else
+      postconf -e 'smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd'
+      postmap /etc/postfix/sasl_passwd
     fi
     postconf -e 'smtp_sasl_security_options = noanonymous'
   


### PR DESCRIPTION
This PR allows using an existing sasl password for the relay instead of defining it through environment variables on the docker-compose file. This existing passsword can for instance be provided by a bind-mount (or a named volume).

I am currently using this mode (without this PR) by bind mounting the file and providing fake user/password to force entrypoint.sh entering the logic. This PR adds an extra condition to enter the logic if the file exists regardless of login and password being provided as env var.

I have done a first commit with some linter fixes, you can ignore them and just cherry pick the second one if you wish